### PR TITLE
setup.py: Install crops_webhook.py as a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(
     install_requires=['Flask>=0.9'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest-pep8'],
+    packages=['.'],
 )


### PR DESCRIPTION
This is so that a user can import crops_webhook easily after
installation.

Signed-off-by: Randy Witt randy.e.witt@linux.intel.com
