### PR TITLE
.travis.yml: Remove python 3.3 testing and add 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 before_install:
   - pip uninstall -y py


### PR DESCRIPTION
Testing under python 3.3 was failing due to setuptools, but since python
3.3 has been EOL for a while, go ahead and remove the test.

Also go ahead and add testing for python 3.6.

Signed-off-by: Randy Witt <randy.e.witt@intel.com>